### PR TITLE
feat: Change IDs to UUIDs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -8,7 +8,8 @@
 use Mix.Config
 
 config :petree_api,
-  ecto_repos: [PetreeApi.Repo]
+  ecto_repos: [PetreeApi.Repo],
+  generators: [binary_id: true]
 
 # Configures the endpoint
 config :petree_api, PetreeApiWeb.Endpoint,

--- a/lib/petree_api/accounts/user.ex
+++ b/lib/petree_api/accounts/user.ex
@@ -2,7 +2,7 @@ defmodule PetreeApi.Accounts.User do
   @moduledoc """
   User schema
   """
-  use Ecto.Schema
+  use PetreeApi.Schema
   import Ecto.Changeset
 
   alias PetreeApi.Trees.Tree

--- a/lib/petree_api/schema.ex
+++ b/lib/petree_api/schema.ex
@@ -1,0 +1,15 @@
+defmodule PetreeApi.Schema do
+  @moduledoc """
+  Ecto Schema Helpers
+  """
+
+  defmacro __using__(_) do
+    quote do
+      use Ecto.Schema
+      import Ecto.Changeset
+
+      @primary_key {:id, :binary_id, read_after_writes: true}
+      @foreign_key_type :binary_id
+    end
+  end
+end

--- a/lib/petree_api/trees/tree.ex
+++ b/lib/petree_api/trees/tree.ex
@@ -2,7 +2,7 @@ defmodule PetreeApi.Trees.Tree do
   @moduledoc """
   Tree schema
   """
-  use Ecto.Schema
+  use PetreeApi.Schema
   import Ecto.Changeset
 
   alias PetreeApi.Accounts.User

--- a/priv/repo/migrations/20201127012133_add_pgcrypto.exs
+++ b/priv/repo/migrations/20201127012133_add_pgcrypto.exs
@@ -1,0 +1,13 @@
+defmodule PetreeApi.Repo.Migrations.AddPgcrypto do
+  @moduledoc """
+  Add PgCrypto so we can have Postgres generate it's own IDs
+  """
+  use Ecto.Migration
+
+  def change do
+    execute(
+      "CREATE EXTENSION IF NOT EXISTS \"pgcrypto\"",
+      "DROP EXTENSION IF EXISTS \"pgcrypto\""
+    )
+  end
+end

--- a/priv/repo/migrations/20201127222844_create_users.exs
+++ b/priv/repo/migrations/20201127222844_create_users.exs
@@ -1,8 +1,12 @@
 defmodule PetreeApi.Repo.Migrations.CreateUsers do
+  @moduledoc """
+  Creating Users in the database
+  """
   use Ecto.Migration
 
   def change do
-    create table(:users) do
+    create table(:users, primary_key: false) do
+      add :id, :binary_id, primary_key: true, default: fragment("gen_random_uuid()")
       add :name, :string
       add :nickname, :string
       add :email, :string

--- a/priv/repo/migrations/20201127233351_create_trees.exs
+++ b/priv/repo/migrations/20201127233351_create_trees.exs
@@ -1,15 +1,19 @@
 defmodule PetreeApi.Repo.Migrations.CreateTrees do
+  @moduledoc """
+  Creating Trees in the database
+  """
   use Ecto.Migration
 
   def change do
-    create table(:trees) do
+    create table(:trees, primary_key: false) do
+      add :id, :binary_id, primary_key: true, default: fragment("gen_random_uuid()")
       add :description, :string
       add :specie, :string
       add :fruitful, :boolean, default: false, null: false
       add :status, :string
       add :lat, :decimal
       add :lng, :decimal
-      add :user_id, references(:users, on_delete: :nothing)
+      add :user_id, references(:users, on_delete: :nothing, type: :binary_id)
 
       timestamps()
     end

--- a/test/petree_api/trees_test.exs
+++ b/test/petree_api/trees_test.exs
@@ -26,7 +26,7 @@ defmodule PetreeApi.TreesTest do
 
     test "create_tree/1 with valid data creates a tree" do
       user = insert(:user)
-      tree = build(:tree, user: user, user_id: user.id)
+      tree = build(:tree, user_id: user.id)
 
       assert {:ok, %Tree{} = created_tree} = Trees.create_tree(tree |> Map.from_struct())
       assert tree.description == created_tree.description
@@ -46,35 +46,35 @@ defmodule PetreeApi.TreesTest do
 
     test "create_tree/1 with invalid fruitful data returns error changeset" do
       user = insert(:user)
-      tree = build(:tree, fruitful: 1, user: user)
+      tree = build(:tree, fruitful: 1, user_id: user.id)
 
       assert {:error, %Ecto.Changeset{}} = Trees.create_tree(tree |> Map.from_struct())
     end
 
     test "create_tree/1 with invalid latatitude data returns error changeset" do
       user = insert(:user)
-      tree = build(:tree, lat: "lat", user: user)
+      tree = build(:tree, lat: "lat", user_id: user.id)
 
       assert {:error, %Ecto.Changeset{}} = Trees.create_tree(tree |> Map.from_struct())
     end
 
     test "create_tree/1 with invalid longitude data returns error changeset" do
       user = insert(:user)
-      tree = build(:tree, lng: "lng", user: user)
+      tree = build(:tree, lng: "lng", user_id: user.id)
 
       assert {:error, %Ecto.Changeset{}} = Trees.create_tree(tree |> Map.from_struct())
     end
 
     test "create_tree/1 with invalid specie data returns error changeset" do
       user = insert(:user)
-      tree = build(:tree, specie: 1, user: user)
+      tree = build(:tree, specie: 1, user_id: user.id)
 
       assert {:error, %Ecto.Changeset{}} = Trees.create_tree(tree |> Map.from_struct())
     end
 
     test "create_tree/1 with invalid status data returns error changeset" do
       user = insert(:user)
-      tree = build(:tree, status: :ok, user: user)
+      tree = build(:tree, status: :ok, user_id: user.id)
 
       assert {:error, %Ecto.Changeset{}} = Trees.create_tree(tree |> Map.from_struct())
     end
@@ -169,7 +169,7 @@ defmodule PetreeApi.TreesTest do
       tree = insert(:tree, user: user)
       invalid_fruitful = 1
 
-      assert {:error, %Ecto.Changeset{}} = Trees.update_tree(tree, %{user_id: invalid_fruitful})
+      assert {:error, %Ecto.Changeset{}} = Trees.update_tree(tree, %{fruitful: invalid_fruitful})
       assert tree = Trees.get_tree!(tree.id)
       assert tree.fruitful != invalid_fruitful
     end
@@ -179,7 +179,7 @@ defmodule PetreeApi.TreesTest do
       tree = insert(:tree, user: user)
       invalid_latitude = "lat"
 
-      assert {:error, %Ecto.Changeset{}} = Trees.update_tree(tree, %{user_id: invalid_latitude})
+      assert {:error, %Ecto.Changeset{}} = Trees.update_tree(tree, %{lat: invalid_latitude})
       assert tree = Trees.get_tree!(tree.id)
       assert tree.lat != invalid_latitude
     end

--- a/test/petree_api_web/controllers/tree_controller_test.exs
+++ b/test/petree_api_web/controllers/tree_controller_test.exs
@@ -64,7 +64,7 @@ defmodule PetreeApiWeb.TreeControllerTest do
 
     test "renders errors when description data is invalid", %{conn: conn} do
       user = insert(:user)
-      tree = build(:tree, user: user, description: 1)
+      tree = build(:tree, user_id: user.id, description: 1)
 
       conn = post(conn, Routes.tree_path(conn, :create), tree: tree |> Map.from_struct())
       assert json_response(conn, 422)["errors"] != %{}
@@ -72,7 +72,7 @@ defmodule PetreeApiWeb.TreeControllerTest do
 
     test "renders errors when fruitful data is invalid", %{conn: conn} do
       user = insert(:user)
-      tree = build(:tree, user: user, fruitful: 1)
+      tree = build(:tree, user_id: user.id, fruitful: 1)
 
       conn = post(conn, Routes.tree_path(conn, :create), tree: tree |> Map.from_struct())
       assert json_response(conn, 422)["errors"] != %{}
@@ -80,7 +80,7 @@ defmodule PetreeApiWeb.TreeControllerTest do
 
     test "renders errors when latitude data is invalid", %{conn: conn} do
       user = insert(:user)
-      tree = build(:tree, user: user, lat: "lat")
+      tree = build(:tree, user_id: user.id, lat: "lat")
 
       conn = post(conn, Routes.tree_path(conn, :create), tree: tree |> Map.from_struct())
       assert json_response(conn, 422)["errors"] != %{}
@@ -88,7 +88,7 @@ defmodule PetreeApiWeb.TreeControllerTest do
 
     test "renders errors when longitude data is invalid", %{conn: conn} do
       user = insert(:user)
-      tree = build(:tree, user: user, lng: "lng")
+      tree = build(:tree, user_id: user.id, lng: "lng")
 
       conn = post(conn, Routes.tree_path(conn, :create), tree: tree |> Map.from_struct())
       assert json_response(conn, 422)["errors"] != %{}
@@ -96,7 +96,7 @@ defmodule PetreeApiWeb.TreeControllerTest do
 
     test "renders errors when specie data is invalid", %{conn: conn} do
       user = insert(:user)
-      tree = build(:tree, user: user, specie: 1)
+      tree = build(:tree, user_id: user.id, specie: 1)
 
       conn = post(conn, Routes.tree_path(conn, :create), tree: tree |> Map.from_struct())
       assert json_response(conn, 422)["errors"] != %{}
@@ -104,7 +104,7 @@ defmodule PetreeApiWeb.TreeControllerTest do
 
     test "renders errors when status data is invalid", %{conn: conn} do
       user = insert(:user)
-      tree = build(:tree, user: user, status: :ok)
+      tree = build(:tree, user_id: user.id, status: :ok)
 
       conn = post(conn, Routes.tree_path(conn, :create), tree: tree |> Map.from_struct())
       assert json_response(conn, 422)["errors"] != %{}


### PR DESCRIPTION
- Change IDs to UUIDs, so that each user and tree record can have its unique identifier
- Fix some tree's tests

-----------------------------

I tried to create a new migration to change the current id field to the binary id type, but it didn't work, so I tried to remove the id field from the user table and create it again with the binary id type, but ecto said no it is possible because the tree model depends on it. So my last option was to change the original migration file to create the table with the correct type id field.

In short, if you already have a database for this project, running mix ecto.migrate will lead you to an error, you will have to drop (mix ecto.drop) your current database and then run mix ecto.setup to create all tables again with the correct id's field type in each table.

PS: This change was made because it looked better to me to create UUIDs instead of sequential integers. It was in the API specification and as nobody opposed to it, I understood that everybody agreed.